### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ FileStore.prototype.get = function get(key, fn) {
   if (Fs.existsSync(cacheFile)) {
     data = Fs.readFileSync(cacheFile);
     data = JSON.parse(data);
+    self.cache[key] = data.expire; //ensures cache sync in all clusters.
   } else {
     return fn(null, null);
   }


### PR DESCRIPTION
Hi

this.cache is bind to a cluster, This means, if this.cache is updated on different cluster, key may not present in other clusters and hence returns an empty response. Consider I have two clusters, A and B 

A = B = OLD
A sets the new data and updates itself as A = NEW but B doesn't update since despite it is reading from file, it relying on this.cache key exist or not.

```
  if (Fs.existsSync(cacheFile)) {
    data = Fs.readFileSync(cacheFile);
    data = JSON.parse(data);
    console.log("LOGGED IN CACHEMAN")
    console.log(data) //Despite there is a data here.
  } else {
    return fn(null, null);
  }

  if (!this.cache[key]) {
    //returns just because this.cache is bind to a cluster.
    console.log("EMPTY CACHE OBJECT")
    return fn(null, null);
  }

```